### PR TITLE
Add support for original styles when creating new html for shared string

### DIFF
--- a/src/Label305/XlsxExtractor/Decorated/SharedString.php
+++ b/src/Label305/XlsxExtractor/Decorated/SharedString.php
@@ -14,16 +14,21 @@ use DOMText;
  */
 class SharedString extends ArrayObject
 {
+    /**
+     * @var int
+     */
+    protected $nextTagIdentifier = 0;
 
     /**
      * Convenience constructor for the user of the API
-     * Strings with <br> <b> <i> and <u> tags are supported.
+     * Strings with <br> <b> <i> <u> and <font> tags are supported.
      * @param $html string
+     * @param SharedString|null $originalSharedString
      * @return SharedString
      */
-    public static function paragraphWithHTML($html)
+    public static function paragraphWithHTML(string $html,?SharedString $originalSharedString = null)
     {
-        $html = "<html>" . strip_tags($html, '<br /><br><b><strong><em><i><u>') . "</html>";
+        $html = "<html>" . strip_tags($html, '<br /><br><b><strong><em><i><u><font>') . "</html>";
         $html = str_replace("<br>", "<br />", $html);
         $html = str_replace("&nbsp;", " ", $html);
         $htmlDom = new DOMDocument;
@@ -31,7 +36,7 @@ class SharedString extends ArrayObject
 
         $sharedString = new SharedString();
         if ($htmlDom->documentElement !== null) {
-            $sharedString->fillWithHTMLDom($htmlDom->documentElement);
+            $sharedString->fillWithHTMLDom($htmlDom->documentElement, $originalSharedString);
         }
 
         return $sharedString;
@@ -41,20 +46,26 @@ class SharedString extends ArrayObject
      * Recursive method to fill paragraph from HTML data
      *
      * @param DOMNode $node
-     * @param int $br
+     * @param SharedString|null $originalSharedString
      * @param bool $bold
      * @param bool $italic
      * @param bool $underline
+     * @param bool $hasStyle
      */
     public function fillWithHTMLDom(
         DOMNode $node,
+        ?SharedString $originalSharedString = null,
         $bold = false,
         $italic = false,
-        $underline = false
+        $underline = false,
+        $hasStyle = false
     ) {
         if ($node instanceof DOMText) {
-
-            $this[] = new SharedStringPart($node->nodeValue, $bold, $italic, $underline);
+            $originalStyle = null;
+            if ($originalSharedString !== null) {
+                $originalStyle = $this->getOriginalStyle($node, $originalSharedString);
+            }
+            $this[] = new SharedStringPart($node->nodeValue, $bold, $italic, $underline, $originalStyle);
 
         } else {
             if ($node->childNodes !== null) {
@@ -68,12 +79,40 @@ class SharedString extends ArrayObject
                 if ($node->nodeName == 'u') {
                     $underline = true;
                 }
+                if ($node->nodeName == 'font') {
+                    $hasStyle = true;
+                }
 
                 foreach ($node->childNodes as $child) {
-                    $this->fillWithHTMLDom($child, $bold, $italic, $underline);
+                    $this->fillWithHTMLDom($child, $originalSharedString, $bold, $italic, $underline, $hasStyle);
                 }
             }
         }
+    }
+
+    /**
+     * @param DOMText $node
+     * @param SharedString $originalSharedString
+     * @return Style|null
+     */
+    private function getOriginalStyle(DOMText $node, SharedString $originalSharedString)
+    {
+        $originalStyle = null;
+        if (array_key_exists($this->nextTagIdentifier, $originalSharedString)) {
+            // Sometimes we extract a single space, but in the Paragraph the space is at the beginning of the sentence
+            $startsWithSpace = strlen($node->nodeValue) > strlen(ltrim($node->nodeValue));
+            if ($startsWithSpace && strlen(ltrim($originalSharedString[$this->nextTagIdentifier]->text)) === 0) {
+                // When the current paragraph has no lengt it may be the space at the beginning
+                $this->nextTagIdentifier++;
+                // Return the next paragraph style
+                if (array_key_exists($this->nextTagIdentifier, $originalSharedString)) {
+                    $originalStyle = $originalSharedString[$this->nextTagIdentifier]->style;
+                }
+            } else {
+                $originalStyle = $originalSharedString[$this->nextTagIdentifier]->style;
+            }
+        }
+        return $originalStyle;
     }
 
     /**
@@ -88,6 +127,7 @@ class SharedString extends ArrayObject
         $boldIsActive = false;
         $italicIsActive = false;
         $underlineIsActive = false;
+        $styleActive = false;
 
         for ($i = 0; $i < count($this); $i++) {
 
@@ -111,6 +151,12 @@ class SharedString extends ArrayObject
                 $openUnderline = true;
             }
 
+            $openStyle = false;
+            if ($sharedStringPart->style !== null && !$styleActive) {
+                $styleActive = true;
+                $openStyle = true;
+            }
+
             $nextSharedStringPart = ($i + 1 < count($this)) ? $this[$i + 1] : null;
             $closeBold = false;
             if ($nextSharedStringPart === null || (!$nextSharedStringPart->bold && $boldIsActive)) {
@@ -130,7 +176,13 @@ class SharedString extends ArrayObject
                 $closeUnderline = true;
             }
 
-            $result .= $sharedStringPart->toHTML($openBold, $openItalic, $openUnderline, $closeBold, $closeItalic, $closeUnderline);
+            $closeStyle = false;
+            if ($nextSharedStringPart === null || ($nextSharedStringPart->style === null && $styleActive)) {
+                $styleActive = false;
+                $closeStyle = true;
+            }
+
+            $result .= $sharedStringPart->toHTML($openBold, $openItalic, $openUnderline, $openStyle, $closeBold, $closeItalic, $closeUnderline, $closeStyle);
         }
 
         return $result;

--- a/src/Label305/XlsxExtractor/Decorated/SharedStringPart.php
+++ b/src/Label305/XlsxExtractor/Decorated/SharedStringPart.php
@@ -103,18 +103,22 @@ class SharedStringPart {
      * @param bool $firstWrappedInBold
      * @param bool $firstWrappedInItalic
      * @param bool $firstWrappedInUnderline
+     * @param bool $firstWrappedInStyle
      * @param bool $lastWrappedInBold
      * @param bool $lastWrappedInItalic
      * @param bool $lastWrappedInUnderline
+     * @param bool $lastWrappedInStyle
      * @return string HTML string
      */
     public function toHTML(
         $firstWrappedInBold = true,
         $firstWrappedInItalic = true,
         $firstWrappedInUnderline = true,
+        $firstWrappedInStyle = true,
         $lastWrappedInBold = true,
         $lastWrappedInItalic = true,
-        $lastWrappedInUnderline = true
+        $lastWrappedInUnderline = true,
+        $lastWrappedInStyle = true
     ) {
         $value = '';
 
@@ -127,8 +131,15 @@ class SharedStringPart {
         if ($this->underline && $firstWrappedInUnderline) {
             $value .= "<u>";
         }
+        if ($this->style !== null && $lastWrappedInStyle) {
+            $value .= "<font>";
+        }
 
         $value .= htmlentities($this->text);
+
+        if ($this->style !== null && $lastWrappedInStyle) {
+            $value .= "</font>";
+        }
 
         if ($this->underline && $lastWrappedInUnderline) {
             $value .= "</u>";

--- a/src/Label305/XlsxExtractor/Decorated/Style.php
+++ b/src/Label305/XlsxExtractor/Decorated/Style.php
@@ -31,7 +31,7 @@ class Style {
      */
     public $scheme;
 
-    function __construct(?string $rFont, ?string $color, ?string $family, ?string $sz, ?string $scheme) {
+    function __construct(?string $rFont = null, ?string $color = null, ?string $family = null, ?string $sz = null, ?string $scheme = null) {
         $this->rFont = $rFont;
         $this->color = $color;
         $this->family = $family;

--- a/tests/ExtractionTest.php
+++ b/tests/ExtractionTest.php
@@ -6,6 +6,7 @@ use Label305\XlsxExtractor\Decorated\DecoratedTextExtractor;
 use Label305\XlsxExtractor\Decorated\DecoratedTextInjector;
 use Label305\XlsxExtractor\Decorated\SharedString;
 use Label305\XlsxExtractor\Decorated\SharedStringPart;
+use Label305\XlsxExtractor\Decorated\Style;
 
 class ExtractionTest extends TestCase {
 
@@ -69,7 +70,7 @@ class ExtractionTest extends TestCase {
         $this->assertEquals(" and ", $mapping[7][2]->text);
         $this->assertEquals("colored", $mapping[7][3]->text);
         $this->assertEquals(" text", $mapping[7][4]->text);
-        $this->assertEquals('This is another description with parially <strong>bold</strong> and <strong>colored</strong> text', $mapping[7]->toHTML());
+        $this->assertEquals('This is another description with parially <strong>bold</strong> and <strong>colored</strong><font> text</font>', $mapping[7]->toHTML());
 
         $mapping[0][0]->text = "Titel voor sheet";
         $mapping[7][0]->text = "Dit is een andere omschrijving met deels ";
@@ -105,13 +106,15 @@ class ExtractionTest extends TestCase {
         $sharedString[] = new SharedStringPart('italic' , false, true);
         $sharedString[] = new SharedStringPart(' and ');
         $sharedString[] = new SharedStringPart('underline' , false, false, true);
+        $sharedString[] = new SharedStringPart(' and ');
+        $sharedString[] = new SharedStringPart('colored text' , false, false, false, new Style());
 
-        $this->assertEquals('This is a test with <strong>bold</strong> and <em>italic</em> and <u>underline</u>', $sharedString->toHTML());
+        $this->assertEquals('This is a test with <strong>bold</strong> and <em>italic</em> and <u>underline</u> and <font>colored text</font>', $sharedString->toHTML());
     }
 
     public function test_sharedString_fillWithHTMLDom()
     {
-        $html = 'This is a test with <strong>bold</strong> and <em>italic</em> and <u>underline</u>';
+        $html = 'This is a test with <strong>bold</strong> and <em>italic</em> and <u>underline</u> and <font>colored text</font>';
         $html = "<html>" . $html . "</html>";
 
         $htmlDom = new DOMDocument;
@@ -129,6 +132,41 @@ class ExtractionTest extends TestCase {
         $this->assertEquals(' and ', $sharedString[4]->text);
         $this->assertEquals('underline', $sharedString[5]->text);
         $this->assertTrue($sharedString[5]->underline);
+        $this->assertEquals(' and ', $sharedString[6]->text);
+        $this->assertEquals('colored text', $sharedString[7]->text);
+    }
+
+    public function test_paragraphWithHTML()
+    {
+        $extractor = new DecoratedTextExtractor();
+        $mapping = $extractor->extractStringsAndCreateMappingFile(__DIR__. '/fixtures/markup.xlsx', __DIR__. '/fixtures/markup-extracted.xlsx');
+
+        $translations = [
+            'Titel voor slide',
+            'Dit is een andere omschrijving met deels <strong>dikgedruk</strong> en <strong>gekleurde</strong> <font>tekst</font>',
+        ];
+
+        foreach ($translations as $key => $translation) {
+            $mapping[$key] = SharedString::paragraphWithHTML($translation, $mapping[$key]);
+        }
+
+        $injector = new DecoratedTextInjector();
+        $injector->injectMappingAndCreateNewFile($mapping, __DIR__. '/fixtures/markup-extracted.xlsx', __DIR__. '/fixtures/markup-injected.xlsx');
+
+        $otherExtractor = new DecoratedTextExtractor();
+        $otherMapping = $otherExtractor->extractStringsAndCreateMappingFile(__DIR__. '/fixtures/markup-injected.xlsx', __DIR__. '/fixtures/markup-injected-extracted.xlsx');
+
+        $this->assertEquals('Titel voor slide', $otherMapping[0][0]->text);
+        $this->assertEquals('Dit is een andere omschrijving met deels ', $otherMapping[1][0]->text);
+        $this->assertEquals('dikgedruk', $otherMapping[1][1]->text);
+        $this->assertEquals(' en ', $otherMapping[1][2]->text);
+        $this->assertEquals('gekleurde', $otherMapping[1][3]->text);
+        $this->assertEquals(' ', $otherMapping[1][4]->text);
+        $this->assertEquals('tekst', $otherMapping[1][5]->text);
+
+        unlink(__DIR__.'/fixtures/markup-extracted.xlsx');
+        unlink(__DIR__.'/fixtures/markup-injected-extracted.xlsx');
+        unlink(__DIR__.'/fixtures/markup-injected.xlsx');
     }
     
 }


### PR DESCRIPTION
Use the original parsed shared string style to apply the new one